### PR TITLE
Added a #trashable? instance method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -20,6 +20,8 @@ The ActsAsTrashable::ClassMethods are mixed into your model when you call acts_a
 
 If you wish to destroy a record without trashing it, perform the destroy inside a disable_trash block on the model (i.e. record.disable_trash{record.destroy}). Also, this gem does not affect the delete or delete_all methods on active record. These will still delete the records directly from the database.
 
+If you want to conditionally disable ActsAsTrashable on a per-instance basis, you can define a #trashable? instance method.  If #trashable? returns true (as does the default implementation), then ActsAsTrashable will save the record as normal.  If it returns false, then the model will not be saved.
+
 == Setup
 
 To create the table structure for ActsAsTrashable::TrashRecord, simply add a migration to your project that calls

--- a/lib/acts_as_trashable.rb
+++ b/lib/acts_as_trashable.rb
@@ -39,7 +39,9 @@ module ActsAsTrashable
   
   module InstanceMethods
     def destroy_with_trash
-      return destroy_without_trash if @acts_as_trashable_disabled
+      return destroy_without_trash if 
+        @acts_as_trashable_disabled || !trashable?
+
       TrashRecord.transaction do
         trash = TrashRecord.new(self)
         trash.save!
@@ -56,6 +58,11 @@ module ActsAsTrashable
       ensure
         @acts_as_trashable_disabled = save_val
       end
+    end
+
+    # Override this in subclasses to provide per-model trashable logic
+    def trashable?
+      true
     end
   end
   

--- a/spec/acts_as_trashable_spec.rb
+++ b/spec/acts_as_trashable_spec.rb
@@ -46,6 +46,16 @@ describe ActsAsTrashable do
       record.destroy.should == :retval
     end
   end
+
+  it "should not create a trash entry when a model is marked as not trashable" do
+    record = TestTrashableModel.new
+    ActsAsTrashable::TrashRecord.should_not_receive(:transaction)
+    ActsAsTrashable::TrashRecord.should_not_receive(:new)
+    record.should_receive(:trashable?).and_return(false)
+    record.should_receive(:really_destroy).and_return(:retval)
+    record.destroy.should == :retval
+  end
+
   
   it "should be able to empty the trash based on age" do
     ActsAsTrashable::TrashRecord.should_receive(:empty_trash).with(1.day, :only => TestTrashableModel)


### PR DESCRIPTION
Hi,

I've added a #trashable? instance method, which allows you to control whether or not a given record will be saved to the trash_records table based on its attributes. I need this so that I can allow partially complete requests to be cancelled as if they were never created in the first place, without polluting the TrashRecord list.
